### PR TITLE
Fixed build error caused by wrong @types/react-router version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "start": "webpack-dev-server",
-    "build": "cross-env NODE_ENV=production webpack --display-error-details --config webpack-production.config.js && uglifyjs ./assets/vendor.js > dist/vendor.js && rm ./dist/*.map",
+    "build": "cross-env NODE_ENV=production webpack --display-error-details --config webpack-production.config.js && uglifyjs ./assets/vendor.js > dist/vendor.js && rimraf ./dist/*.map",
     "buildvendor": "webpack --config webpack-vendor.config.js",
     "clean": "rimraf dist",
     "lint": "tslint --force \"src/**/*.ts*\" && sass-lint -v -q src/**/*.scss",
@@ -74,7 +74,7 @@
     "@types/react-dom": "^0.14.23",
     "@types/react-hot-loader": "^3.0.1",
     "@types/react-redux": "^4.4.36",
-    "@types/react-router": "^2.0.44",
+    "@types/react-router": "^3.0.2",
     "@types/react-router-redux": "^4.0.40",
     "codecov": "^1.0.1",
     "copy-webpack-plugin": "^4.0.0",


### PR DESCRIPTION
When I tried to perform `npm run build`, I met following issue.

```
ERROR in D:\src\js\boilerplates\react-redux-boilerplate\node_modules\@types\react-router-redux\index.d.ts
(9,10): error TS2305: Module '"D:/src/js/boilerplates/react-redux-boilerplate/node_modules/@types/react-router/index"' has no exported member 'Location'.
``` 

And I also have fixed cross-platform issue. 
